### PR TITLE
Feat: Expand "Introduce Yourself" command

### DIFF
--- a/assets/personalities/generic/bot_config.json
+++ b/assets/personalities/generic/bot_config.json
@@ -96,7 +96,7 @@
     "I always learn so much when I’m around you.",
     "Is there anything you can’t do!?"
   ],
-  "ACTION_WHAT_CAN_YOU_DO_TEXT": "Well, at the moment you can ask me to:\n",
+  "ACTION_WHAT_CAN_YOU_DO_TEXT": "At the moment you can ask me to:\n",
   "RESPONSE_BUG_POOL": [
     "https://media.giphy.com/media/xTiTnGuHmcaQeWSryE/giphy.gif",
     "https://media.giphy.com/media/A1SNSC8s40O64/giphy.gif",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "team-management-bot",
   "author": "Tzahi Furmanski <tzahi.fur@gmail.com> (https://github.com/tzahifurmanski/)",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "repository": "https://github.com/tzahifurmanski/team-management-bot",
   "description": "A slack bot for engineering teams",
   "main": "dist/app.js",

--- a/src/actions/asks/ask_channel_stats.ts
+++ b/src/actions/asks/ask_channel_stats.ts
@@ -1,5 +1,5 @@
 import { BotAction } from "../base_action";
-import {AskChannelStatsParams, getAskChannelStatsParameters, getStartingDate, removeTimeInfoFromDate} from "../utils";
+import {AskChannelStatsParams, getAskChannelStatsParameters, getStartingDate} from "../utils";
 import {
   AsksChannelStatsResult,
   getChannelMessages,
@@ -11,8 +11,8 @@ import {sanitizeCommandInput, sendGenericError} from "../../integrations/slack/u
 
 export class AskChannelStats implements BotAction {
   getHelpText(): string {
-    return "Get you some stats about what goes on in your team channel (`ask channel stats`, default for 7 days)." +
-        "You can provide number of days / weeks / months (`ask channel stats 15 days`, `ask channel stats 2 weeks`)\n";
+    return "`ask channel stats` - Get statistics about what goes on in your team channel (default for 7 days)." +
+        "You can provide number of days / weeks / months (For example: `ask channel stats 15 days`, `ask channel stats 2 weeks`).";
   }
 
   isEnabled(): boolean {

--- a/src/actions/asks/ask_channel_status.ts
+++ b/src/actions/asks/ask_channel_status.ts
@@ -1,5 +1,5 @@
 import { BotAction } from "../base_action";
-import {AskChannelStatsParams, getAskChannelStatsParameters, getStartingDate, removeTimeInfoFromDate} from "../utils";
+import {AskChannelStatsParams, getAskChannelStatsParameters, getStartingDate} from "../utils";
 import {
   AsksChannelStatsResult,
   getChannelMessages,
@@ -11,8 +11,7 @@ import {sanitizeCommandInput, sendGenericError} from "../../integrations/slack/u
 
 export class AskChannelStatus implements BotAction {
   getHelpText(): string {
-    return "Get you the status of requests in your team ask channel, for a specific timeframe (`ask channel status`, defaults for 7 days). You can provide number of days / weeks / months (`ask channel status 15 days`, `ask channel status 2 weeks`)\n";
-
+    return "`ask channel status` - Get the status of requests in your team ask channel, for a specific timeframe (defaults for 7 days). You can provide number of days / weeks / months (For example: `ask channel status 15 days`, `ask channel status 2 weeks`).";
   }
 
   isEnabled(): boolean {

--- a/src/actions/asks/ask_channel_status_for_yesterday.ts
+++ b/src/actions/asks/ask_channel_status_for_yesterday.ts
@@ -9,11 +9,16 @@ import {
 import { TEAM_ASK_CHANNEL_ID } from "../../integrations/slack/consts";
 import { sendSlackMessage } from "../../integrations/slack/messages";
 import {sanitizeCommandInput} from "../../integrations/slack/utils";
-import {TEAM_FOLKS} from "../../consts";
+import {ASK_CHANNEL_STATS_CRON, TEAM_FOLKS} from "../../consts";
+import cronstrue from "cronstrue";
 
 export class AskChannelStatusForYesterday implements BotAction {
   getHelpText(): string {
-    return "Get you the status of requests in your team ask channel from yesterday and a current status going back for the last 60 days (`ask channel status for yesterday`). This is the same as what the recurring ask channel post contains.";
+    let helpMessage = "`ask channel status for yesterday` - Get the status of requests in your team ask channel from yesterday and a current status going back for the last 60 days."
+    if (ASK_CHANNEL_STATS_CRON) {
+      helpMessage += `\n*A recurring ask channel post is scheduled to be sent ${cronstrue.toString(ASK_CHANNEL_STATS_CRON)}.*`;
+    }
+    return helpMessage;
   }
 
   isEnabled(): boolean {

--- a/src/actions/asks/compliment.ts
+++ b/src/actions/asks/compliment.ts
@@ -15,7 +15,7 @@ const COMPLIMENTS = botConfig.ACTION_COMPLIMENT_POOL.concat((TEAM_SPECIFIC_COMPL
 
 export class Compliment implements BotAction {
   getHelpText(): string {
-    return "Compliment someone (`compliment @Tzahi`)";
+    return "`compliment @Tzahi` - Compliment someone.";
   }
 
   isEnabled(): boolean {

--- a/src/actions/asks/group_ask_channel_monthly_stats.ts
+++ b/src/actions/asks/group_ask_channel_monthly_stats.ts
@@ -12,7 +12,7 @@ import {
 
 export class GroupAskChannelMonthlyStats implements BotAction {
   getHelpText(): string {
-    return "Get you some stats about what goes on in your department (`group ask channel stats`, default for 7 days). You can provide number of days / weeks / months (`group ask channel stats 15 days`, `group ask channel stats 2 weeks`)";
+    return "`group ask channel stats` - Get statistics about what goes on in your department (default for 7 days). You can provide number of days / weeks / months (For example: `group ask channel stats 15 days`, `group ask channel stats 2 weeks`)";
   }
 
   isEnabled(): boolean {

--- a/src/actions/asks/help.ts
+++ b/src/actions/asks/help.ts
@@ -1,12 +1,18 @@
 import {BotAction} from "../base_action";
 import {sendSlackMessage} from "../../integrations/slack/messages";
 import {botConfig} from "../../consts";
-import {ASKS_ACTIONS} from "./index";
 import {sanitizeCommandInput} from "../../integrations/slack/utils";
 
 export class Help implements BotAction {
+    actionsList : BotAction[] = [];
+
+    // To avoid dependencies deadlock, actions list will be set externally
+    setActionsList(list : BotAction[]) {
+        this.actionsList = list;
+    }
+
     getHelpText(): string {
-        return "Return information about currently available commands (`help`, `what can you do`)";
+        return "`help`/`what can you do` - Return information about currently available commands";
     }
 
     isEnabled(): boolean {
@@ -19,10 +25,10 @@ export class Help implements BotAction {
             sanitizeCommandInput(event.text).startsWith("what can you do"));
     }
 
+    // TODO: This currently says what is enabled. Maybe also say what actions are disabled (and what they can do).
     async performAction(event: any): Promise<void> {
         let message = `${botConfig.ACTION_WHAT_CAN_YOU_DO_TEXT}\n`
-        // TODO: This currently says what is enabled. Maybe also say what actions are disabled (and what they can do).
-        ASKS_ACTIONS.forEach((action) => {
+        this.actionsList.forEach((action) => {
             message += `• ${action.getHelpText()}\n`;
         });
 

--- a/src/actions/asks/index.ts
+++ b/src/actions/asks/index.ts
@@ -9,7 +9,9 @@ import { MonitoredChannelSummaryStats } from "./monitored_channel_stats";
 import { AskChannelStatusForYesterday } from "./ask_channel_status_for_yesterday";
 import { OncallTicketsStatus } from "./oncall_tickets_status";
 import { Help } from "./help";
+import { Status } from "./status";
 
+const helpCommand = new Help();
 const ACTIONS_LIST : BotAction[] = [
   new AskChannelStatusForYesterday(),
   new AskChannelStatus(),
@@ -17,10 +19,11 @@ const ACTIONS_LIST : BotAction[] = [
   new GroupAskChannelMonthlyStats(),
   new OncallTicketsStatus(),
   new MonitoredChannelSummaryStats(),
-  new IntroduceYourself(),
   new Compliment(),
   new MeaningOfLife(),
-  new Help(),
+  new Status(),
+  helpCommand,
+  new IntroduceYourself(),
   ];
 
 export let ASKS_ACTIONS: BotAction[] = [];
@@ -38,3 +41,5 @@ ACTIONS_LIST.forEach( (action) => {
   }
 })
 console.log("Actions list loading is complete.");
+
+helpCommand.setActionsList(ASKS_ACTIONS);

--- a/src/actions/asks/introduce_yourself.ts
+++ b/src/actions/asks/introduce_yourself.ts
@@ -1,11 +1,14 @@
 import { BotAction } from '../base_action';
-import {botConfig, TEAM_NAME} from "../../consts";
+import {BOT_NAME, botConfig, TEAM_NAME} from "../../consts";
+import {BOT_ID, TEAM_ASK_CHANNEL_ID} from "../../integrations/slack/consts";
+import {AskChannelStatusForYesterday} from "./ask_channel_status_for_yesterday";
+import {Help} from "./help";
 
 const { sendSlackMessage } = require('../../integrations/slack/messages');
 
 export class IntroduceYourself implements BotAction {
   getHelpText(): string {
-    return "Introduce myself (`introduce yourself`)";
+    return "`introduce yourself` - Introduce the bot and it's capabilities";
   }
 
   isEnabled(): boolean {
@@ -20,11 +23,24 @@ export class IntroduceYourself implements BotAction {
   }
 
   async performAction(event: any): Promise<void> {
-    // TODO: Is there a way to get this from the user's description?
-    await sendSlackMessage(
-      `${botConfig.ACTION_INTRODUCE_YOURSELF_TEXT} I serve at the pleasure of the ${TEAM_NAME} team.`,
-      event.channel,
-      event.thread_ts
-    );
+    // Send welcome message
+    await sendSlackMessage(`${botConfig.ACTION_INTRODUCE_YOURSELF_TEXT} I serve at the pleasure of the ${TEAM_NAME} team :wave:\n` +
+        "Here are some things you should know about me :in-progress:", event.channel, event.thread_ts);
+
+    // Send details (in thread)
+
+    // If asks channel status feature is enabled:
+    const askChannelStatusForYesterdayCommand = new AskChannelStatusForYesterday()
+    if (askChannelStatusForYesterdayCommand.isEnabled()) {
+      const asksMessage = await sendSlackMessage("Most people use me for managing your asks channel. Here is some useful information: (:thread:)", event.channel, event.thread_ts);
+      await sendSlackMessage(`I track the requests in your asks channel (<#${TEAM_ASK_CHANNEL_ID}>) and can post a status report, helping you track the open asks you currently have. For example:`, event.channel, asksMessage.ts);
+      await askChannelStatusForYesterdayCommand.performAction({...event, thread_ts: asksMessage.ts});
+      await sendSlackMessage(`Cool huh? :smiley:\nThis can be done by running ${askChannelStatusForYesterdayCommand.getHelpText()}`, event.channel, asksMessage.ts);
+      await sendSlackMessage("How does it work? In order to determine what is pending, in-progress or done, I look for :white_check_mark: for a completed task, and :in-progress: for in progress (the rest is ‘unhandled’). Most teams find this sufficient, but in case you prefer to use different emojis, these are configurable :slightly_smiling_face:", event.channel, asksMessage.ts);
+    }
+
+    const result = await sendSlackMessage("More things to know about me! :excited: (:thread:)", event.channel, event.thread_ts);
+    await sendSlackMessage(`You can communicate with me everywhere - Either by DMing me with what you'd like me to run (DM <@${BOT_ID}> with \`help\`) or tagging me in a message (\`@${BOT_NAME}> help\`) in a channel I'm in.`, event.channel, result.ts);
+    await new Help().performAction({...event, thread_ts: result.ts});
   }
 }

--- a/src/actions/asks/meaning_of_life.ts
+++ b/src/actions/asks/meaning_of_life.ts
@@ -4,7 +4,7 @@ const { sendSlackMessage } = require("../../integrations/slack/messages");
 
 export class MeaningOfLife implements BotAction {
   getHelpText(): string {
-    return "Answer what is the meaning of life (`meaning of life`)";
+    return "`meaning of life` - Obviously, explain the meaning of life.";
   }
 
   isEnabled(): boolean {

--- a/src/actions/asks/monitored_channel_stats.ts
+++ b/src/actions/asks/monitored_channel_stats.ts
@@ -15,11 +15,10 @@ import {
   MONITORED_CHANNEL_ID,
   MONITORED_CHANNEL_TRIGGER
 } from "../../consts";
-import {ASKS_ACTIONS} from "./index";
 
 export class MonitoredChannelSummaryStats implements BotAction {
   getHelpText(): string {
-    return "Monitor a certain channel for success/failure messages. For example, can be used to track successful deployments";
+    return `\`${MONITORED_CHANNEL_TRIGGER}\` - Monitor a certain channel for success/failure messages. For example, can be used to track successful deployments`;
   }
 
   isEnabled(): boolean {

--- a/src/actions/asks/oncall_tickets_status.ts
+++ b/src/actions/asks/oncall_tickets_status.ts
@@ -17,7 +17,7 @@ import {sanitizeCommandInput} from "../../integrations/slack/utils";
 
 export class OncallTicketsStatus implements BotAction {
     getHelpText(): string {
-        return "Provide a summary of the current tickets currently active for your oncall team (`oncall tickets status`)";
+        return "`oncall tickets status` - Provide a summary of the current tickets currently active for your oncall team.";
     }
 
     isEnabled(): boolean {

--- a/src/actions/asks/status.ts
+++ b/src/actions/asks/status.ts
@@ -1,5 +1,4 @@
 import { BotAction } from '../base_action';
-import {botConfig, TEAM_NAME} from "../../consts";
 import {BOT_ID} from "../../integrations/slack/consts";
 import {sanitizeCommandInput} from "../../integrations/slack/utils";
 
@@ -7,7 +6,7 @@ const { sendSlackMessage } = require('../../integrations/slack/messages');
 
 export class Status implements BotAction {
   getHelpText(): string {
-    return "Returns the current status and version of the bot.";
+    return "`status` - Returns the current status and version of the bot.";
   }
 
   isEnabled(): boolean {
@@ -21,7 +20,7 @@ export class Status implements BotAction {
 
   async performAction(event: any): Promise<void> {
     await sendSlackMessage(
-      `${BOT_ID} version ${process.env.npm_package_version} is up and running.`,
+      `Bot <@${BOT_ID}> (ID ${BOT_ID}), version ${process.env.npm_package_version}.`,
       event.channel,
       event.thread_ts
     );

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -27,7 +27,7 @@ export const botConfig = require(`../assets/personalities/${BOT_PERSONALITY}/bot
 
 // If we got a bot name, override the default:
 const BOT_NAME_PLACEHOLDER = "<BOT_NAME>";
-const BOT_NAME = process.env.BOT_NAME || "";
+export const BOT_NAME = process.env.BOT_NAME || "";
 if(BOT_NAME) {
     botConfig.BOT_NAME=BOT_NAME;
     botConfig.ACTION_INTRODUCE_YOURSELF_TEXT = botConfig.ACTION_INTRODUCE_YOURSELF_TEXT.replace(BOT_NAME_PLACEHOLDER, BOT_NAME);


### PR DESCRIPTION
Expand the information returned by this command to provide teams first using the bot with useful information. Also:
* Enable the Status command (was unreachable before) and update the text.
* Standardize the help text for all commands
* Add the asks channel cron job information to the command help text