### PR TITLE
Feat: Support multiple Zendesk views

### DIFF
--- a/config-variables.txt
+++ b/config-variables.txt
@@ -42,9 +42,9 @@ BOT_USER_OAUTH_ACCESS_TOKEN=
 # =================
 
 # Ask Channel Status
-ASK_CHANNEL_STATS_CRON= # A comma (',') separated list of a cron expression for the bot to post in the team ask channel with a current status. For example, '30 08 * * 0-5', which is every day at 8:30 UTC, on Sunday to Friday.
-TEAM_ASK_CHANNEL_ID= # A comma (',') separated list of the Slack IDs for the ask channels for the bot to track. Supply either a name, or an ID.
-TEAM_ASK_CHANNEL_NAME= # A comma (',') separated list of the Slack ask channel names for the bot to track. Supply either a name, or an ID.
+ASK_CHANNEL_STATS_CRON= # A separator ('|') separated list of cron expressions for the bot to post in the team ask channel with a current status. For example, '30 08 * * 0-5', which is every day at 8:30 UTC, on Sunday to Friday.
+TEAM_ASK_CHANNEL_ID= # A comma (',') separated list of the Slack IDs for the ask channels for the bot to track.
+TEAM_ASK_CHANNEL_NAME= # A comma (',') separated list of the Slack ask channel names for the bot to track.
 ALLOWED_BOTS= # Optional, a comma (',') separated list of bot usernames to include in the asks channel summary.
 
 # Ask Channel Stats - Optional, needed for the reporting feature
@@ -59,14 +59,14 @@ GROUP_ASK_CHANNELS=
 ZENDESK_TOKEN= # The Basic auth token used to connect to Zendesk
 ZENDESK_BASE_URL= # Base URL for your Zendesk instance
 
-# Oncall Tickets Status Configurations
-MONITORED_ZENDESK_VIEW= # ID of the Zendesk View used by the oncall
-MONITORED_ZENDESK_FILTER_FIELD_ID= # Optional. ID of the a field to filter Zendesk tickets by
+# Zendesk Tickets Status Configurations
+ZENDESK_MONITORED_VIEW= # A comma (',') separated list of IDs for the Zendesk views to monitor.
+MONITORED_ZENDESK_FILTER_FIELD_ID= # Optional. ID of a field to filter Zendesk tickets by
 MONITORED_ZENDESK_FILTER_FIELD_VALUES= # Optional. A list of allowed values for the Zendesk tickets filter field.
 
-ONCALL_CHANNEL_ID= # ID of the Slack channel used by the oncall team
-ONCALL_CHANNEL_NAME= # Name of the Slack channel used by the oncall team
-ONCALL_TICKETS_STATS_CRON=
+ZENDESK_TICKETS_CHANNEL_ID= # A comma (',') separated list of IDs of the Slack channels to report a status in.
+ZENDESK_TICKETS_CHANNEL_NAME= # A comma (',') separated list of Names of the Slack channels to report a status in.
+ZENDESK_TICKETS_STATS_CRON= # A separator ('|') separated list of cron expressions for the bot to post a status in.
 
 # Reactions
 REACTIONS_IN_PROGRESS= # Optional. List of Slack reaction names that will indicate that an ask is in progress.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "team-management-bot",
   "author": "Tzahi Furmanski <tzahi.fur@gmail.com> (https://github.com/tzahifurmanski/)",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "repository": "https://github.com/tzahifurmanski/team-management-bot",
   "description": "A slack bot for engineering teams",
   "main": "dist/app.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "team-management-bot",
   "author": "Tzahi Furmanski <tzahi.fur@gmail.com> (https://github.com/tzahifurmanski/)",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "repository": "https://github.com/tzahifurmanski/team-management-bot",
   "description": "A slack bot for engineering teams",
   "main": "dist/app.js",

--- a/src/actions/asks/index.ts
+++ b/src/actions/asks/index.ts
@@ -6,7 +6,7 @@ import { MeaningOfLife } from "./meaning_of_life";
 import { GroupAskChannelMonthlyStats } from "./group_ask_channel_monthly_stats";
 import { MonitoredChannelSummaryStats } from "./monitored_channel_stats";
 import { AskChannelStatusForYesterday } from "./ask_channel_status_for_yesterday";
-import { OncallTicketsStatus } from "./oncall_tickets_status";
+import { ZendeskTicketsStatus } from "./zendesk_tickets_status";
 import { Help } from "./help";
 import { Status } from "./status";
 
@@ -15,7 +15,7 @@ const ACTIONS_LIST: BotAction[] = [
   new AskChannelStatusForYesterday(),
   new AskChannelStatusStatsOrSummary(),
   new GroupAskChannelMonthlyStats(),
-  new OncallTicketsStatus(),
+  new ZendeskTicketsStatus(),
   new MonitoredChannelSummaryStats(),
   new Compliment(),
   new MeaningOfLife(),

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -124,11 +124,15 @@ export const BOT_RESPONSES_CHANNELS: string[] = handleListParameter(
 export const ASK_CHANNEL_STATS_CRON: string[] = handleListParameter(
   process.env.ASK_CHANNEL_STATS_CRON,
   "",
-  ",",
+  "|",
   false
 );
-export const ONCALL_TICKETS_STATS_CRON =
-  process.env.ONCALL_TICKETS_STATS_CRON || "";
+export const ZENDESK_TICKETS_STATS_CRON = handleListParameter(
+  process.env.ZENDESK_TICKETS_STATS_CRON,
+  "",
+  "|",
+  false
+);
 
 // Team Configurations
 export const TEAM_NAME = process.env.TEAM_NAME || "";

--- a/src/integrations/slack/consts.ts
+++ b/src/integrations/slack/consts.ts
@@ -67,8 +67,17 @@ export let GROUP_ASK_CHANNELS_LIST = new Map<string, string>();
 export const ZENDESK_TOKEN = process.env.ZENDESK_TOKEN || "";
 export const ZENDESK_BASE_URL = process.env.ZENDESK_BASE_URL || "";
 
-// Oncall Tickets Status Configurations
-export const MONITORED_ZENDESK_VIEW = process.env.MONITORED_ZENDESK_VIEW || "";
+// Zendesk Tickets Status Configurations
+export const ZENDESK_MONITORED_VIEW = handleListParameter(
+  process.env.ZENDESK_MONITORED_VIEW
+);
+export const ZENDESK_TICKETS_CHANNEL_ID: string[] = handleListParameter(
+  process.env.ZENDESK_TICKETS_CHANNEL_ID
+);
+export const ZENDESK_TICKETS_CHANNEL_NAME: string[] = handleListParameter(
+  process.env.ZENDESK_TICKETS_CHANNEL_NAME
+);
+
 export const MONITORED_ZENDESK_FILTER_FIELD_ID =
   process.env.MONITORED_ZENDESK_FILTER_FIELD_ID || "";
 
@@ -78,9 +87,6 @@ export const MONITORED_ZENDESK_FILTER_FIELD_VALUES: string[] =
     "",
     ","
   );
-
-export let ONCALL_CHANNEL_ID: string = process.env.ONCALL_CHANNEL_ID || "";
-const ONCALL_CHANNEL_NAME: string = process.env.ONCALL_CHANNEL_NAME || "";
 
 // Resolve the slack dynamic variables
 export const loadSlackConfig = async (slackClient: any) => {
@@ -105,13 +111,26 @@ export const loadSlackConfig = async (slackClient: any) => {
       return false;
     }
 
+    if (ZENDESK_TICKETS_CHANNEL_ID.length === 0) {
+      for (const channelName of ZENDESK_TICKETS_CHANNEL_NAME) {
+        const channelId: string = await getConversationId(
+          slackClient,
+          channelName
+        );
+        ZENDESK_TICKETS_CHANNEL_ID.push(channelId);
+      }
+    } else if (
+      ZENDESK_TICKETS_CHANNEL_ID.length != ZENDESK_TICKETS_CHANNEL_NAME.length
+    ) {
+      console.log(
+        "Error: TICKETS_CHANNEL_ID and TICKETS_CHANNEL_NAME have different lengths"
+      );
+      return false;
+    }
+
     TEAM_CODE_REVIEW_CHANNEL_ID =
       TEAM_CODE_REVIEW_CHANNEL_ID ||
       (await getConversationId(slackClient, TEAM_CODE_REVIEW_CHANNEL_NAME));
-
-    ONCALL_CHANNEL_ID =
-      ONCALL_CHANNEL_ID ||
-      (await getConversationId(slackClient, ONCALL_CHANNEL_NAME));
 
     // TODO: Allow to add defaults
     GROUP_ASK_CHANNELS_LIST = new Map<string, string>();


### PR DESCRIPTION
The bot now supports monitoring multiple Zendesk views.

In addition:
* Feature renamed from "Oncall tickets support" to "Zendesk tickets support".
* Cron fields are now split by | (as , is allowed in cron expressions)
