### PR TITLE
Feat: Prevent duplicate 'ask channel status for yesterday' scheduled messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "team-management-bot",
   "author": "Tzahi Furmanski <tzahi.fur@gmail.com> (https://github.com/tzahifurmanski/)",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "repository": "https://github.com/tzahifurmanski/team-management-bot",
   "description": "A slack bot for engineering teams",
   "main": "dist/app.js",


### PR DESCRIPTION
* Update version to 1.5.10
* Implement a safety to make sure we don't double-post scheduled 'ask channel status for yesterday' messages.