### PR TITLE
Feat: Add Authorized Admins feature

### DIFF
--- a/config-variables.txt
+++ b/config-variables.txt
@@ -87,3 +87,12 @@ MONITORED_ZENDESK_FILTER_FIELD_VALUES= # Optional. A list of allowed values for 
 ZENDESK_TICKETS_CHANNEL_ID= # A comma (',') separated list of IDs of the Slack channels to report a status in.
 ZENDESK_TICKETS_CHANNEL_NAME= # A comma (',') separated list of Names of the Slack channels to report a status in.
 ZENDESK_TICKETS_STATS_CRON= # A separator ('|') separated list of cron expressions for the bot to post a status in.
+
+
+
+# Admin Authorization
+====================
+ADMIN_USER_IDS=U12345678,U87654321  # Comma-separated list of Slack user IDs who are admins
+ADMIN_COMMANDS=team                 # Commands that require admin authorization
+ADMIN_LOG_ACTIONS=true              # Whether to log admin actions (recommended for security)
+ADMIN_REQUIRE_CONFIRMATION=true     # Require confirmation for destructive operations

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
+// jest.config.js - Updated for CI/CD performance
 module.exports = {
   moduleFileExtensions: ["ts", "js"],
   transform: {
@@ -12,4 +13,15 @@ module.exports = {
   testEnvironment: "node",
   coveragePathIgnorePatterns: ["/node_modules/"],
   reporters: ["default", "jest-junit"],
+
+  // Add these settings to reduce memory usage
+  maxWorkers: 2, // Limits parallel test execution
+  maxConcurrency: 5, // Limits async operations
+  testTimeout: 30000, // Increases timeout to 30 seconds
+  forceExit: true, // Forces Jest to exit after tests complete
+  detectOpenHandles: true, // Helps identify resource leaks
+
+  // Add this to divide tests into smaller batches if needed
+  // Silent version for CI
+  silent: process.env.CI === "true", // Reduces console output in CI
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "team-management-bot",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "team-management-bot",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -26,7 +26,7 @@
         "jest": "29.7.0",
         "jest-junit": "16.0.0",
         "mockdate": "3.0.5",
-        "prettier": "3.3.3",
+        "prettier": "^3.3.3",
         "supertest": "7.0.0",
         "ts-jest": "29.2.4",
         "tsc-watch": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
     "mockdate": "3.0.5",
-    "prettier": "3.3.3",
+    "prettier": "^3.3.3",
     "supertest": "7.0.0",
     "ts-jest": "29.2.4",
     "tsc-watch": "6.2.0",
@@ -42,6 +42,8 @@
     "debug": "tsc-watch --project tsconfig.json --onSuccess 'node dist/server.js'",
     "test": "cross-env NODE_ENV=test ENV_FILE=.tests_env jest --testTimeout=10000",
     "coverage": "cross-env NODE_ENV=test ENV_FILE=.tests_env jest --testTimeout=10000 --collectCoverage=true",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
+    "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "prettier:check:ci": "./node_modules/.bin/prettier --check ."
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "team-management-bot",
   "author": "Tzahi Furmanski <tzahi.fur@gmail.com> (https://github.com/tzahifurmanski/)",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "repository": "https://github.com/tzahifurmanski/team-management-bot",
   "description": "A slack bot for engineering teams",
   "main": "dist/app.js",

--- a/src/actions/asks/index.ts
+++ b/src/actions/asks/index.ts
@@ -10,6 +10,7 @@ import { ZendeskTicketsStatus } from "./zendesk_tickets_status";
 import { Help } from "./help";
 import { Status } from "./status";
 import { logger } from "../../settings/server_consts";
+import { TeamAdmin } from "./team_admin";
 
 const helpCommand = new Help();
 const ACTIONS_LIST: BotAction[] = [
@@ -21,6 +22,7 @@ const ACTIONS_LIST: BotAction[] = [
   new Compliment(),
   new MeaningOfLife(),
   new Status(),
+  new TeamAdmin(),
   helpCommand,
   new IntroduceYourself(helpCommand),
 ];

--- a/src/actions/asks/team_admin.ts
+++ b/src/actions/asks/team_admin.ts
@@ -27,7 +27,7 @@ export class TeamAdmin implements BotAction {
         slackClient,
         "Sorry, you're not authorized to perform admin commands. Please contact a bot administrator if you need assistance.",
         event.channel,
-        event.thread_ts
+        event.thread_ts,
       );
       return;
     }
@@ -62,14 +62,14 @@ export class TeamAdmin implements BotAction {
           slackClient,
           "No teams are currently configured.",
           event.channel,
-          event.thread_ts
+          event.thread_ts,
         );
         return;
       }
 
       // Convert teams to array for processing
       const teamsArray = Array.from(TEAMS_LIST.entries()).map(
-        ([channelId, team]) => team
+        ([channelId, team]) => team,
       );
 
       // Create summary message
@@ -78,7 +78,7 @@ export class TeamAdmin implements BotAction {
         slackClient,
         summaryMessage,
         event.channel,
-        event.thread_ts
+        event.thread_ts,
       );
 
       // Create detailed team listings - split into multiple messages to avoid formatting issues
@@ -88,13 +88,13 @@ export class TeamAdmin implements BotAction {
       for (const chunk of teamChunks) {
         const detailMessage = this.createDetailedTeamMessage(
           chunk,
-          teamsArray.indexOf(chunk[0])
+          teamsArray.indexOf(chunk[0]),
         );
         await sendSlackMessage(
           slackClient,
           detailMessage,
           event.channel,
-          event.thread_ts
+          event.thread_ts,
         );
       }
     } catch (error) {
@@ -103,7 +103,7 @@ export class TeamAdmin implements BotAction {
         slackClient,
         "An error occurred while listing teams. Please check the logs for details.",
         event.channel,
-        event.thread_ts
+        event.thread_ts,
       );
     }
   }
@@ -139,7 +139,7 @@ export class TeamAdmin implements BotAction {
    */
   private createDetailedTeamMessage(
     teamChunk: any[],
-    startIndex: number
+    startIndex: number,
   ): string {
     let message = `*Detailed Team Information (${startIndex + 1}-${startIndex + teamChunk.length})*\n\n`;
 
@@ -207,7 +207,7 @@ export class TeamAdmin implements BotAction {
       slackClient,
       helpText,
       event.channel,
-      event.thread_ts
+      event.thread_ts,
     );
   }
 }

--- a/src/actions/asks/team_admin.ts
+++ b/src/actions/asks/team_admin.ts
@@ -1,0 +1,238 @@
+// src/actions/asks/team_admin.ts
+import { BotAction } from "../base_action";
+import { logger } from "../../settings/server_consts";
+import { sendSlackMessage } from "../../integrations/slack/messages";
+import { sanitizeCommandInput } from "../../integrations/slack/utils";
+import { adminAuthService } from "../../services/AdminAuthorizationService";
+import { TEAMS_LIST } from "../../settings/team_consts";
+import {
+  extractIDFromChannelString,
+  extractNameFromChannelString,
+} from "../utils";
+import { SlackWebClient } from "../../integrations/consts";
+
+// Store pending confirmation requests
+// interface ConfirmationRequest {
+//   action: string;
+//   actionArgs: any;
+//   expiryTime: number;
+// }
+
+export class TeamAdmin implements BotAction {
+  //   private pendingConfirmations: Map<string, ConfirmationRequest> = new Map();
+
+  getHelpText(): string {
+    return "`team admin` - Admin commands for managing teams (restricted to authorized admins)";
+  }
+
+  isEnabled(): boolean {
+    return true; // Always available, but authorization is checked in performAction
+  }
+
+  doesMatch(event: any): boolean {
+    return sanitizeCommandInput(event.text).startsWith("team");
+  }
+
+  async performAction(event: any, slackClient: any): Promise<void> {
+    const command = sanitizeCommandInput(event.text);
+
+    // // Check if this is a confirmation
+    // if (command.startsWith("confirm")) {
+    //   await this.handleConfirmation(
+    //     command.substring("confirm".length).trim(),
+    //     event,
+    //     slackClient
+    //   );
+    //   return;
+    // }
+
+    // For all other commands, check authorization
+    if (!adminAuthService.isAuthorized(event.user, command)) {
+      await sendSlackMessage(
+        slackClient,
+        "Sorry, you're not authorized to perform admin commands. Please contact a bot administrator if you need assistance.",
+        event.channel,
+        event.thread_ts
+      );
+      return;
+    }
+
+    // Parse command parts
+    const parts = command.split(" ");
+
+    // Handle different commands
+    if (parts.length > 1 && parts[0] === "team") {
+      const subCommand = parts[1];
+
+      switch (subCommand) {
+        case "list":
+          await this.listTeams(event, slackClient);
+          break;
+        case "help":
+        default:
+          await this.showHelp(event, slackClient);
+          break;
+      }
+    } else {
+      await this.showHelp(event, slackClient);
+    }
+  }
+  /**
+   * Optimized team listing method for handling large numbers of teams reliably
+   */
+  private async listTeams(event: any, slackClient: any): Promise<void> {
+    try {
+      if (TEAMS_LIST.size === 0) {
+        await sendSlackMessage(
+          slackClient,
+          "No teams are currently configured.",
+          event.channel,
+          event.thread_ts
+        );
+        return;
+      }
+
+      // Convert teams to array for processing
+      const teamsArray = Array.from(TEAMS_LIST.entries()).map(
+        ([channelId, team]) => team
+      );
+
+      // Create summary message
+      const summaryMessage = this.createSummaryMessage(teamsArray);
+      await sendSlackMessage(
+        slackClient,
+        summaryMessage,
+        event.channel,
+        event.thread_ts
+      );
+
+      // Create detailed team listings - split into multiple messages to avoid formatting issues
+      // Format: 5 teams per message
+      const teamChunks = this.chunkArray(teamsArray, 5);
+
+      for (const chunk of teamChunks) {
+        const detailMessage = this.createDetailedTeamMessage(
+          chunk,
+          teamsArray.indexOf(chunk[0])
+        );
+        await sendSlackMessage(
+          slackClient,
+          detailMessage,
+          event.channel,
+          event.thread_ts
+        );
+      }
+    } catch (error) {
+      logger.error("Error listing teams:", error);
+      await sendSlackMessage(
+        slackClient,
+        "An error occurred while listing teams. Please check the logs for details.",
+        event.channel,
+        event.thread_ts
+      );
+    }
+  }
+
+  /**
+   * Create a summary table of all teams
+   */
+  private createSummaryMessage(teams: any[]): string {
+    let message = `*Team Configuration Summary*\n`;
+    message += `Total Teams: *${teams.length}* | `;
+    message += `With Zendesk: *${teams.filter((team) => team.zendesk_channel_id).length}* | `;
+    message += `With Cron Schedule: *${teams.filter((team) => team.ask_channel_cron).length}* | `;
+    message += `With Code Review: *${teams.filter((team) => team.code_review_channel_id).length}*\n\n`;
+
+    // Create a markdown table with key information
+    message += "| # | Team Name | Ask Channel | Schedule |\n";
+    message += "|---|-----------|-------------|----------|\n";
+
+    teams.forEach((team, index) => {
+      const rowNumber = index + 1;
+      const askChannel = `<#${team.ask_channel_id}|${team.ask_channel_name}>`;
+      const cronSchedule = team.ask_channel_cron || "—";
+
+      message += `| ${rowNumber} | ${team.ask_channel_name} | ${askChannel} | \`${cronSchedule}\` |\n`;
+    });
+
+    message += "\n_Detailed information follows in separate messages_";
+    return message;
+  }
+
+  /**
+   * Create a detailed message for a chunk of teams
+   */
+  private createDetailedTeamMessage(
+    teamChunk: any[],
+    startIndex: number
+  ): string {
+    let message = `*Detailed Team Information (${startIndex + 1}-${startIndex + teamChunk.length})*\n\n`;
+
+    teamChunk.forEach((team, chunkIndex) => {
+      const globalIndex = startIndex + chunkIndex;
+      const teamNumber = globalIndex + 1;
+
+      // Add the team header with proper bold formatting
+      message += `*Team #${teamNumber}: ${team.ask_channel_name}*\n`;
+
+      // Create a formatted text block with indentation instead of a code block
+      message += `• Ask Channel: <#${team.ask_channel_id}|${team.ask_channel_name}>\n`;
+      message += `• Allowed Bots: ${team.allowed_bots && team.allowed_bots.length > 0 && team.allowed_bots[0] !== "" ? team.allowed_bots.join(", ") : "None"}\n`;
+      message += `• Last Status: ${new Date(team.ask_channel_cron_last_sent).toISOString().split("T")[0]}\n`;
+
+      // Zendesk info
+      if (team.zendesk_channel_id) {
+        message += `• Zendesk Channel: <#${team.zendesk_channel_id}|${team.zendesk_channel_name}>\n`;
+      }
+
+      if (team.zendesk_monitored_view_id) {
+        message += `• Zendesk View ID: ${team.zendesk_monitored_view_id}\n`;
+      }
+
+      // Schedules
+      if (team.ask_channel_cron) {
+        message += `• Ask Schedule: \`${team.ask_channel_cron}\`\n`;
+      }
+
+      if (team.zendesk_channel_cron) {
+        message += `• Zendesk Schedule: \`${team.zendesk_channel_cron}\`\n`;
+      }
+
+      // Add a separator between teams (except after the last one)
+      if (chunkIndex < teamChunk.length - 1) {
+        message += "\n———————————————————————————\n\n";
+      }
+    });
+
+    return message;
+  }
+
+  /**
+   * Split an array into chunks of specified size
+   */
+  private chunkArray<T>(array: T[], chunkSize: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < array.length; i += chunkSize) {
+      chunks.push(array.slice(i, i + chunkSize));
+    }
+    return chunks;
+  }
+
+  /**
+   * Display help information
+   */
+  private async showHelp(event: any, slackClient: any): Promise<void> {
+    const helpText = `
+*Team Administration Commands*
+
+• \`team list\` - List all configured teams
+    `;
+
+    await sendSlackMessage(
+      slackClient,
+      helpText,
+      event.channel,
+      event.thread_ts
+    );
+  }
+}

--- a/src/actions/asks/team_admin.ts
+++ b/src/actions/asks/team_admin.ts
@@ -5,22 +5,8 @@ import { sendSlackMessage } from "../../integrations/slack/messages";
 import { sanitizeCommandInput } from "../../integrations/slack/utils";
 import { adminAuthService } from "../../services/AdminAuthorizationService";
 import { TEAMS_LIST } from "../../settings/team_consts";
-import {
-  extractIDFromChannelString,
-  extractNameFromChannelString,
-} from "../utils";
-import { SlackWebClient } from "../../integrations/consts";
-
-// Store pending confirmation requests
-// interface ConfirmationRequest {
-//   action: string;
-//   actionArgs: any;
-//   expiryTime: number;
-// }
 
 export class TeamAdmin implements BotAction {
-  //   private pendingConfirmations: Map<string, ConfirmationRequest> = new Map();
-
   getHelpText(): string {
     return "`team admin` - Admin commands for managing teams (restricted to authorized admins)";
   }
@@ -30,23 +16,12 @@ export class TeamAdmin implements BotAction {
   }
 
   doesMatch(event: any): boolean {
-    return sanitizeCommandInput(event.text).startsWith("team");
+    return sanitizeCommandInput(event.text).startsWith("team ");
   }
 
   async performAction(event: any, slackClient: any): Promise<void> {
     const command = sanitizeCommandInput(event.text);
 
-    // // Check if this is a confirmation
-    // if (command.startsWith("confirm")) {
-    //   await this.handleConfirmation(
-    //     command.substring("confirm".length).trim(),
-    //     event,
-    //     slackClient
-    //   );
-    //   return;
-    // }
-
-    // For all other commands, check authorization
     if (!adminAuthService.isAuthorized(event.user, command)) {
       await sendSlackMessage(
         slackClient,

--- a/src/services/AdminAuthorizationService.ts
+++ b/src/services/AdminAuthorizationService.ts
@@ -1,0 +1,99 @@
+// src/services/AdminAuthorizationService.ts
+import { logger } from "../settings/server_consts";
+import { handleListParameter } from "../utils";
+
+/**
+ * Service for checking if users are authorized to perform admin actions
+ */
+export class AdminAuthorizationService {
+  private adminUserIds: string[] = [];
+  private adminCommands: string[] = [];
+  private logActions: boolean = true;
+  private requireConfirmation: boolean = true;
+  private confirmationRequests: Map<
+    string,
+    { userId: string; action: string; expires: number }
+  > = new Map();
+
+  constructor() {
+    this.loadConfiguration();
+  }
+
+  /**
+   * Load admin configuration from environment variables
+   */
+  private loadConfiguration(): void {
+    // Load admin user IDs (safe with empty default)
+    this.adminUserIds = handleListParameter(process.env.ADMIN_USER_IDS || "");
+
+    // Load admin commands
+    this.adminCommands = handleListParameter(
+      process.env.ADMIN_COMMANDS || "team"
+    );
+
+    // Parse boolean values safely
+    this.logActions = process.env.ADMIN_LOG_ACTIONS !== "false"; // Default to true
+    this.requireConfirmation =
+      process.env.ADMIN_REQUIRE_CONFIRMATION !== "false"; // Default to true
+
+    logger.debug(`Loaded ${this.adminUserIds.length} admin users`);
+    logger.debug(`Admin commands: ${this.adminCommands.join(", ")}`);
+  }
+
+  /**
+   * Check if a user is authorized as an admin
+   * @param userId The Slack user ID to check
+   * @returns True if the user is an admin, false otherwise
+   */
+  public isUserAdmin(userId: string): boolean {
+    return this.adminUserIds.includes(userId);
+  }
+
+  /**
+   * Check if a command requires admin authorization
+   * @param command The command to check
+   * @returns True if the command requires admin authorization, false otherwise
+   */
+  public isAdminCommand(command: string): boolean {
+    // Check if any admin command is a prefix of the given command
+    return this.adminCommands.some((adminCommand) =>
+      command.startsWith(adminCommand)
+    );
+  }
+
+  /**
+   * Check if a user is authorized to perform a specific command
+   * @param userId The Slack user ID to check
+   * @param command The command being executed
+   * @returns True if the user is authorized, false otherwise
+   */
+  public isAuthorized(userId: string, command: string): boolean {
+    // If command doesn't require admin privileges, allow it
+    if (!this.isAdminCommand(command)) {
+      return true;
+    }
+
+    // Check if user is an admin
+    const isAdmin = this.isUserAdmin(userId);
+
+    // Log the authorization check if enabled
+    if (this.logActions) {
+      logger.info(
+        `Admin authorization check: User ${userId} ${isAdmin ? "allowed" : "denied"} for command "${command}"`
+      );
+    }
+
+    return isAdmin;
+  }
+
+  /**
+   * Get all admin user IDs
+   * This is mainly for testing purposes
+   */
+  public getAdminUserIds(): string[] {
+    return [...this.adminUserIds];
+  }
+}
+
+// Create and export singleton instance
+export const adminAuthService = new AdminAuthorizationService();

--- a/src/services/AdminAuthorizationService.ts
+++ b/src/services/AdminAuthorizationService.ts
@@ -28,7 +28,7 @@ export class AdminAuthorizationService {
 
     // Load admin commands
     this.adminCommands = handleListParameter(
-      process.env.ADMIN_COMMANDS || "team"
+      process.env.ADMIN_COMMANDS || "team",
     );
 
     // Parse boolean values safely
@@ -57,7 +57,7 @@ export class AdminAuthorizationService {
   public isAdminCommand(command: string): boolean {
     // Check if any admin command is a prefix of the given command
     return this.adminCommands.some((adminCommand) =>
-      command.startsWith(adminCommand)
+      command.startsWith(adminCommand),
     );
   }
 
@@ -79,7 +79,7 @@ export class AdminAuthorizationService {
     // Log the authorization check if enabled
     if (this.logActions) {
       logger.info(
-        `Admin authorization check: User ${userId} ${isAdmin ? "allowed" : "denied"} for command "${command}"`
+        `Admin authorization check: User ${userId} ${isAdmin ? "allowed" : "denied"} for command "${command}"`,
       );
     }
 

--- a/test/actions/asks/team_admin.test.ts
+++ b/test/actions/asks/team_admin.test.ts
@@ -182,6 +182,25 @@ describe("TeamAdmin", () => {
     expect(secondDetailCall).toContain("*Team #6: test-ask-6*");
   });
 
+  test("no teams to list", async () => {
+    // Mock authorization check to succeed
+    (adminAuthService.isAuthorized as jest.Mock).mockReturnValue(true);
+
+    // Set event text
+    mockEvent.text = "team list";
+
+    // Call performAction
+    await teamAdmin.performAction(mockEvent, mockSlackClient);
+
+    // Check that summary message was sent
+    expect(sendSlackMessage).toHaveBeenCalledWith(
+      mockSlackClient,
+      expect.stringContaining("No teams are currently configured."),
+      mockEvent.channel,
+      mockEvent.thread_ts,
+    );
+  });
+
   test("chunkArray should correctly divide teams", () => {
     // Create test data
     const testArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -191,5 +210,36 @@ describe("TeamAdmin", () => {
 
     // Verify chunking
     expect(chunkedArray).toEqual([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]]);
+  });
+
+  test("getHelpText returns expected help description", () => {
+    const helpText = teamAdmin.getHelpText();
+    expect(helpText).toContain("team admin");
+    expect(helpText).toContain("Admin commands");
+    expect(helpText).toContain("restricted to authorized admins");
+  });
+
+  test("should show help information when 'team help' is used", async () => {
+    // Set event text
+    mockEvent.text = "team help";
+
+    // Call performAction
+    await teamAdmin.performAction(mockEvent, mockSlackClient);
+
+    // Check help message was sent
+    expect(sendSlackMessage).toHaveBeenCalledTimes(1);
+    expect(sendSlackMessage).toHaveBeenCalledWith(
+      mockSlackClient,
+      expect.any(String),
+      mockEvent.channel,
+      mockEvent.thread_ts,
+    );
+
+    // Get the help message content
+    const helpMessage = (sendSlackMessage as jest.Mock).mock.calls[0][1];
+
+    // Verify help content includes essential sections
+    expect(helpMessage).toContain("Team Administration Commands");
+    expect(helpMessage).toContain("team list");
   });
 });

--- a/test/actions/asks/team_admin.test.ts
+++ b/test/actions/asks/team_admin.test.ts
@@ -1,0 +1,209 @@
+// test/actions/asks/team_admin.test.ts
+import { TeamAdmin } from "../../../src/actions/asks/team_admin";
+import { adminAuthService } from "../../../src/services/AdminAuthorizationService";
+import { TEAMS_LIST } from "../../../src/settings/team_consts";
+import { sendSlackMessage } from "../../../src/integrations/slack/messages";
+
+// Mock dependencies
+jest.mock("../../../src/services/AdminAuthorizationService", () => ({
+  adminAuthService: {
+    isAuthorized: jest.fn(),
+    requestConfirmation: jest.fn(),
+    confirmAction: jest.fn(),
+  },
+}));
+
+jest.mock("../../../src/integrations/slack/messages", () => ({
+  sendSlackMessage: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock("../../../src/settings/team_consts", () => ({
+  TEAMS_LIST: new Map(),
+}));
+
+jest.mock("../../../src/utils", () => ({
+  handleListParameter: jest
+    .fn()
+    .mockImplementation((input) => (input ? input.split(",") : [])),
+}));
+
+jest.mock("../../../src/actions/utils", () => ({
+  extractIDFromChannelString: jest.fn().mockImplementation((input) => {
+    const match = input.match(/<#([A-Z0-9]+)\|.+>/);
+    return match ? match[1] : null;
+  }),
+  extractNameFromChannelString: jest.fn().mockImplementation((input) => {
+    const match = input.match(/<#[A-Z0-9]+\|(.+)>/);
+    return match ? match[1] : null;
+  }),
+}));
+
+describe("TeamAdmin", () => {
+  let teamAdmin: TeamAdmin;
+  let mockSlackClient: any;
+  let mockEvent: any;
+
+  beforeEach(() => {
+    // Clear all mocks
+    jest.clearAllMocks();
+
+    // Create instance
+    teamAdmin = new TeamAdmin();
+
+    // Create mock Slack client
+    mockSlackClient = {
+      conversations: {
+        info: jest
+          .fn()
+          .mockResolvedValue({ channel: { name: "test-channel" } }),
+      },
+    };
+
+    // Create mock event
+    mockEvent = {
+      user: "U12345",
+      channel: "C67890",
+      thread_ts: "1234567890.123456",
+    };
+
+    // Reset TEAMS_LIST
+    TEAMS_LIST.clear();
+  });
+
+  test("isEnabled should return true", () => {
+    expect(teamAdmin.isEnabled()).toBe(true);
+  });
+
+  test("doesMatch should match team commands", () => {
+    expect(teamAdmin.doesMatch({ text: "team list" })).toBe(true);
+    expect(teamAdmin.doesMatch({ text: "team add" })).toBe(true);
+    expect(teamAdmin.doesMatch({ text: "team remove" })).toBe(true);
+    expect(teamAdmin.doesMatch({ text: "teams" })).toBe(false);
+    expect(teamAdmin.doesMatch({ text: "help" })).toBe(false);
+  });
+
+  test("should deny access to unauthorized users", async () => {
+    // Mock authorization check to fail
+    (adminAuthService.isAuthorized as jest.Mock).mockReturnValue(false);
+
+    // Set event text
+    mockEvent.text = "team list";
+
+    // Call performAction
+    await teamAdmin.performAction(mockEvent, mockSlackClient);
+
+    // Check authorization was called
+    expect(adminAuthService.isAuthorized).toHaveBeenCalledWith(
+      "U12345",
+      "team list"
+    );
+
+    // Check error message was sent
+    expect(sendSlackMessage).toHaveBeenCalledWith(
+      mockSlackClient,
+      expect.stringContaining("not authorized"),
+      mockEvent.channel,
+      mockEvent.thread_ts
+    );
+  });
+
+  test("should show help for authorized users", async () => {
+    // Mock authorization check to succeed
+    (adminAuthService.isAuthorized as jest.Mock).mockReturnValue(true);
+
+    // Set event text
+    mockEvent.text = "team help";
+
+    // Call performAction
+    await teamAdmin.performAction(mockEvent, mockSlackClient);
+
+    // Check help message was sent
+    expect(sendSlackMessage).toHaveBeenCalledWith(
+      mockSlackClient,
+      expect.stringContaining("Team Administration Commands"),
+      mockEvent.channel,
+      mockEvent.thread_ts
+    );
+  });
+
+  test("should list teams", async () => {
+    // Mock authorization check to succeed
+    (adminAuthService.isAuthorized as jest.Mock).mockReturnValue(true);
+
+    // Add a test team
+    TEAMS_LIST.set("C12345", {
+      ask_channel_id: "C12345",
+      ask_channel_name: "test-ask",
+      ask_channel_cron: "0 9 * * 1-5",
+      ask_channel_cron_last_sent: new Date(),
+      allowed_bots: ["TestBot"],
+      zendesk_channel_id: "C67890",
+      zendesk_channel_name: "test-zendesk",
+      zendesk_monitored_view_id: "123456",
+      zendesk_aggregated_field_id: "",
+      zendesk_field_id: "",
+      zendesk_field_values: [],
+      zendesk_channel_cron: "",
+      code_review_channel_id: "",
+      code_review_channel_name: "",
+    });
+
+    // Set event text
+    mockEvent.text = "team list";
+
+    // Call performAction
+    await teamAdmin.performAction(mockEvent, mockSlackClient);
+
+    // Check list message was sent
+    expect(sendSlackMessage).toHaveBeenCalledWith(
+      mockSlackClient,
+      expect.stringContaining("Configured Teams"),
+      mockEvent.channel,
+      mockEvent.thread_ts
+    );
+  });
+
+//   test("should handle confirmation request for team removal", async () => {
+//     // Mock authorization check to succeed
+//     (adminAuthService.isAuthorized as jest.Mock).mockReturnValue(true);
+
+//     // Mock confirmation request
+//     (adminAuthService.requestConfirmation as jest.Mock).mockReturnValue(
+//       "abc123"
+//     );
+
+//     // Add a test team
+//     TEAMS_LIST.set("C12345", {
+//       ask_channel_id: "C12345",
+//       ask_channel_name: "test-ask",
+//       ask_channel_cron: "0 9 * * 1-5",
+//       ask_channel_cron_last_sent: new Date(),
+//       allowed_bots: ["TestBot"],
+//       zendesk_channel_id: "",
+//       zendesk_channel_name: "",
+//       zendesk_monitored_view_id: "",
+//       zendesk_aggregated_field_id: "",
+//       zendesk_field_id: "",
+//       zendesk_field_values: [],
+//       zendesk_channel_cron: "",
+//       code_review_channel_id: "",
+//       code_review_channel_name: "",
+//     });
+
+//     // Set event text
+//     mockEvent.text = "team remove <#C12345|test-ask>";
+
+//     // Call performAction
+//     await teamAdmin.performAction(mockEvent, mockSlackClient);
+
+//     // Check confirmation message was sent
+//     expect(sendSlackMessage).toHaveBeenCalledWith(
+//       mockSlackClient,
+//       expect.stringContaining("Are you sure you want to remove"),
+//       mockEvent.channel,
+//       mockEvent.thread_ts
+//     );
+//   });
+
+//   // Additional tests for other functionality...
+// });

--- a/test/actions/asks/team_admin.test.ts
+++ b/test/actions/asks/team_admin.test.ts
@@ -95,7 +95,7 @@ describe("TeamAdmin", () => {
     // Check authorization was called
     expect(adminAuthService.isAuthorized).toHaveBeenCalledWith(
       "U12345",
-      "team list"
+      "team list",
     );
 
     // Check error message was sent
@@ -103,7 +103,7 @@ describe("TeamAdmin", () => {
       mockSlackClient,
       expect.stringContaining("not authorized"),
       mockEvent.channel,
-      mockEvent.thread_ts
+      mockEvent.thread_ts,
     );
   });
 
@@ -122,7 +122,7 @@ describe("TeamAdmin", () => {
       mockSlackClient,
       expect.stringContaining("Team Administration Commands"),
       mockEvent.channel,
-      mockEvent.thread_ts
+      mockEvent.thread_ts,
     );
   });
 
@@ -161,7 +161,7 @@ describe("TeamAdmin", () => {
       mockSlackClient,
       expect.stringContaining("Team Configuration Summary"),
       mockEvent.channel,
-      mockEvent.thread_ts
+      mockEvent.thread_ts,
     );
 
     // Check that summary contains the table header

--- a/test/services/AdminAuthorizationService.test.ts
+++ b/test/services/AdminAuthorizationService.test.ts
@@ -85,54 +85,5 @@ describe("AdminAuthorizationService", () => {
     expect(authService.isAuthorized("U12345", "help")).toBe(true);
     expect(authService.isAuthorized("U67890", "status")).toBe(true);
     expect(authService.isAuthorized("U99999", "help")).toBe(true);
-//   });
-
-//   test("should support confirmation flow", () => {
-//     // Set up environment
-//     process.env.ADMIN_USER_IDS = "U12345,U67890";
-//     process.env.ADMIN_COMMANDS = "team,admin,config";
-//     process.env.ADMIN_REQUIRE_CONFIRMATION = "true";
-
-//     const authService = new AdminAuthorizationService();
-
-//     // Request confirmation
-//     const token = authService.requestConfirmation("U12345", "delete team");
-
-//     // Confirmation should succeed for same user
-//     expect(authService.confirmAction(token, "U12345")).toBe(true);
-
-//     // Token should be consumed
-//     expect(authService.confirmAction(token, "U12345")).toBe(false);
-//   });
-
-//   test("should reject confirmation from wrong user", () => {
-//     // Set up environment
-//     process.env.ADMIN_USER_IDS = "U12345,U67890";
-//     process.env.ADMIN_COMMANDS = "team,admin,config";
-//     process.env.ADMIN_REQUIRE_CONFIRMATION = "true";
-
-//     const authService = new AdminAuthorizationService();
-
-//     // Request confirmation
-//     const token = authService.requestConfirmation("U12345", "delete team");
-
-//     // Confirmation should fail for different user
-//     expect(authService.confirmAction(token, "U67890")).toBe(false);
-//   });
-
-//   test("should bypass confirmation if disabled", () => {
-//     // Set up environment
-//     process.env.ADMIN_USER_IDS = "U12345,U67890";
-//     process.env.ADMIN_COMMANDS = "team,admin,config";
-//     process.env.ADMIN_REQUIRE_CONFIRMATION = "false";
-
-//     const authService = new AdminAuthorizationService();
-
-//     // Request confirmation (should return special token)
-//     const token = authService.requestConfirmation("U12345", "delete team");
-//     expect(token).toBe("no-confirmation-required");
-
-//     // Confirmation should succeed without checking token
-//     expect(authService.confirmAction("any-token", "U12345")).toBe(true);
-//   });
-// });
+  });
+});

--- a/test/services/AdminAuthorizationService.test.ts
+++ b/test/services/AdminAuthorizationService.test.ts
@@ -1,4 +1,4 @@
-// test/services/AdminAuthorizationService.test.ts
+// test/services/AdminAuthorizationService.test.ts - Optimized version
 import { AdminAuthorizationService } from "../../src/services/AdminAuthorizationService";
 
 describe("AdminAuthorizationService", () => {
@@ -14,76 +14,50 @@ describe("AdminAuthorizationService", () => {
     process.env = originalEnv;
   });
 
-  test("should load admin user IDs from environment variables", () => {
-    // Set up environment
-    process.env.ADMIN_USER_IDS = "U12345,U67890";
+  // Group related tests to reduce test setup/teardown overhead
+  describe("admin identification", () => {
+    test("should load admin user IDs and identify admins correctly", () => {
+      // Set up environment
+      process.env.ADMIN_USER_IDS = "U12345,U67890";
 
-    const authService = new AdminAuthorizationService();
+      const authService = new AdminAuthorizationService();
 
-    // Check admin users were loaded correctly
-    expect(authService.getAdminUserIds()).toEqual(["U12345", "U67890"]);
+      // Test loading and identification
+      expect(authService.getAdminUserIds()).toEqual(["U12345", "U67890"]);
+      expect(authService.isUserAdmin("U12345")).toBe(true);
+      expect(authService.isUserAdmin("U67890")).toBe(true);
+      expect(authService.isUserAdmin("U99999")).toBe(false);
+    });
+
+    test("should handle empty admin user IDs", () => {
+      // Set up environment
+      process.env.ADMIN_USER_IDs = "";
+
+      const authService = new AdminAuthorizationService();
+
+      // Check admin users list is empty
+      expect(authService.getAdminUserIds()).toEqual([]);
+    });
   });
 
-  test("should handle empty admin user IDs", () => {
-    // Set up environment
-    process.env.ADMIN_USER_IDS = "";
+  describe("command authorization", () => {
+    test("should identify admin commands and authorize properly", () => {
+      // Set up environment
+      process.env.ADMIN_USER_IDS = "U12345,U67890";
+      process.env.ADMIN_COMMANDS = "team,admin,config";
+      process.env.ADMIN_LOG_ACTIONS = "false"; // Disable logging for tests
 
-    const authService = new AdminAuthorizationService();
+      const authService = new AdminAuthorizationService();
 
-    // Check admin users list is empty
-    expect(authService.getAdminUserIds()).toEqual([]);
-  });
+      // Test command check
+      expect(authService.isAdminCommand("team list")).toBe(true);
+      expect(authService.isAdminCommand("admin users")).toBe(true);
+      expect(authService.isAdminCommand("help")).toBe(false);
 
-  test("should correctly identify admin users", () => {
-    // Set up environment
-    process.env.ADMIN_USER_IDS = "U12345,U67890";
-
-    const authService = new AdminAuthorizationService();
-
-    // Test admin user check
-    expect(authService.isUserAdmin("U12345")).toBe(true);
-    expect(authService.isUserAdmin("U67890")).toBe(true);
-    expect(authService.isUserAdmin("U99999")).toBe(false);
-  });
-
-  test("should correctly identify admin commands", () => {
-    // Set up environment
-    process.env.ADMIN_COMMANDS = "team,admin,config";
-
-    const authService = new AdminAuthorizationService();
-
-    // Test command check
-    expect(authService.isAdminCommand("team list")).toBe(true);
-    expect(authService.isAdminCommand("team add")).toBe(true);
-    expect(authService.isAdminCommand("admin users")).toBe(true);
-    expect(authService.isAdminCommand("config set")).toBe(true);
-    expect(authService.isAdminCommand("help")).toBe(false);
-    expect(authService.isAdminCommand("status")).toBe(false);
-  });
-
-  test("should authorize admin users for admin commands", () => {
-    // Set up environment
-    process.env.ADMIN_USER_IDS = "U12345,U67890";
-    process.env.ADMIN_COMMANDS = "team,admin,config";
-
-    const authService = new AdminAuthorizationService();
-
-    // Test authorization
-    expect(authService.isAuthorized("U12345", "team list")).toBe(true);
-    expect(authService.isAuthorized("U67890", "admin users")).toBe(true);
-    expect(authService.isAuthorized("U99999", "team add")).toBe(false);
-  });
-
-  test("should authorize all users for non-admin commands", () => {
-    // Set up environment
-    process.env.ADMIN_USER_IDS = "U12345,U67890";
-    process.env.ADMIN_COMMANDS = "team,admin,config";
-
-    const authService = new AdminAuthorizationService();
-
-    // Test authorization for non-admin commands
-    expect(authService.isAuthorized("U12345", "help")).toBe(true);
-    expect(authService.isAuthorized("U67890", "status")).toBe(true);
-    expect(authService.isAuthorized("U99999", "help")).toBe(true);
+      // Test authorization
+      expect(authService.isAuthorized("U12345", "team list")).toBe(true);
+      expect(authService.isAuthorized("U99999", "team list")).toBe(false);
+      expect(authService.isAuthorized("U99999", "help")).toBe(true);
+    });
   });
 });

--- a/test/services/AdminAuthorizationService.test.ts
+++ b/test/services/AdminAuthorizationService.test.ts
@@ -1,0 +1,138 @@
+// test/services/AdminAuthorizationService.test.ts
+import { AdminAuthorizationService } from "../../src/services/AdminAuthorizationService";
+
+describe("AdminAuthorizationService", () => {
+  // Save and restore environment variables
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test("should load admin user IDs from environment variables", () => {
+    // Set up environment
+    process.env.ADMIN_USER_IDS = "U12345,U67890";
+
+    const authService = new AdminAuthorizationService();
+
+    // Check admin users were loaded correctly
+    expect(authService.getAdminUserIds()).toEqual(["U12345", "U67890"]);
+  });
+
+  test("should handle empty admin user IDs", () => {
+    // Set up environment
+    process.env.ADMIN_USER_IDS = "";
+
+    const authService = new AdminAuthorizationService();
+
+    // Check admin users list is empty
+    expect(authService.getAdminUserIds()).toEqual([]);
+  });
+
+  test("should correctly identify admin users", () => {
+    // Set up environment
+    process.env.ADMIN_USER_IDS = "U12345,U67890";
+
+    const authService = new AdminAuthorizationService();
+
+    // Test admin user check
+    expect(authService.isUserAdmin("U12345")).toBe(true);
+    expect(authService.isUserAdmin("U67890")).toBe(true);
+    expect(authService.isUserAdmin("U99999")).toBe(false);
+  });
+
+  test("should correctly identify admin commands", () => {
+    // Set up environment
+    process.env.ADMIN_COMMANDS = "team,admin,config";
+
+    const authService = new AdminAuthorizationService();
+
+    // Test command check
+    expect(authService.isAdminCommand("team list")).toBe(true);
+    expect(authService.isAdminCommand("team add")).toBe(true);
+    expect(authService.isAdminCommand("admin users")).toBe(true);
+    expect(authService.isAdminCommand("config set")).toBe(true);
+    expect(authService.isAdminCommand("help")).toBe(false);
+    expect(authService.isAdminCommand("status")).toBe(false);
+  });
+
+  test("should authorize admin users for admin commands", () => {
+    // Set up environment
+    process.env.ADMIN_USER_IDS = "U12345,U67890";
+    process.env.ADMIN_COMMANDS = "team,admin,config";
+
+    const authService = new AdminAuthorizationService();
+
+    // Test authorization
+    expect(authService.isAuthorized("U12345", "team list")).toBe(true);
+    expect(authService.isAuthorized("U67890", "admin users")).toBe(true);
+    expect(authService.isAuthorized("U99999", "team add")).toBe(false);
+  });
+
+  test("should authorize all users for non-admin commands", () => {
+    // Set up environment
+    process.env.ADMIN_USER_IDS = "U12345,U67890";
+    process.env.ADMIN_COMMANDS = "team,admin,config";
+
+    const authService = new AdminAuthorizationService();
+
+    // Test authorization for non-admin commands
+    expect(authService.isAuthorized("U12345", "help")).toBe(true);
+    expect(authService.isAuthorized("U67890", "status")).toBe(true);
+    expect(authService.isAuthorized("U99999", "help")).toBe(true);
+//   });
+
+//   test("should support confirmation flow", () => {
+//     // Set up environment
+//     process.env.ADMIN_USER_IDS = "U12345,U67890";
+//     process.env.ADMIN_COMMANDS = "team,admin,config";
+//     process.env.ADMIN_REQUIRE_CONFIRMATION = "true";
+
+//     const authService = new AdminAuthorizationService();
+
+//     // Request confirmation
+//     const token = authService.requestConfirmation("U12345", "delete team");
+
+//     // Confirmation should succeed for same user
+//     expect(authService.confirmAction(token, "U12345")).toBe(true);
+
+//     // Token should be consumed
+//     expect(authService.confirmAction(token, "U12345")).toBe(false);
+//   });
+
+//   test("should reject confirmation from wrong user", () => {
+//     // Set up environment
+//     process.env.ADMIN_USER_IDS = "U12345,U67890";
+//     process.env.ADMIN_COMMANDS = "team,admin,config";
+//     process.env.ADMIN_REQUIRE_CONFIRMATION = "true";
+
+//     const authService = new AdminAuthorizationService();
+
+//     // Request confirmation
+//     const token = authService.requestConfirmation("U12345", "delete team");
+
+//     // Confirmation should fail for different user
+//     expect(authService.confirmAction(token, "U67890")).toBe(false);
+//   });
+
+//   test("should bypass confirmation if disabled", () => {
+//     // Set up environment
+//     process.env.ADMIN_USER_IDS = "U12345,U67890";
+//     process.env.ADMIN_COMMANDS = "team,admin,config";
+//     process.env.ADMIN_REQUIRE_CONFIRMATION = "false";
+
+//     const authService = new AdminAuthorizationService();
+
+//     // Request confirmation (should return special token)
+//     const token = authService.requestConfirmation("U12345", "delete team");
+//     expect(token).toBe("no-confirmation-required");
+
+//     // Confirmation should succeed without checking token
+//     expect(authService.confirmAction("any-token", "U12345")).toBe(true);
+//   });
+// });


### PR DESCRIPTION
This allows to configure admins slack users, that are able to manage the bot configuration.
To start with, this will add a `team list` command.